### PR TITLE
멘토 페이지 api 연동

### DIFF
--- a/src/apis/mentor/index.tsx
+++ b/src/apis/mentor/index.tsx
@@ -50,3 +50,21 @@ export const confirmConsultation = async (id: number): Promise<void> => {
 export const rejectConsultation = async (id: number): Promise<void> => {
   await apiInstance.delete(`/api/v1/consultation/${id}`);
 };
+
+export const getPastConsultations = async (
+  page: number,
+  size: number,
+  consultationStatus: 'FINISHED'
+): Promise<ConsultationListResponse> => {
+  const response = await apiInstance.get<ConsultationListResponse>(
+    '/api/v1/member/consultation',
+    {
+      params: {
+        page,
+        size,
+        consultation_status: consultationStatus,
+      },
+    }
+  );
+  return response.data;
+};

--- a/src/apis/mentor/index.tsx
+++ b/src/apis/mentor/index.tsx
@@ -1,7 +1,10 @@
 import apiInstance from '@/apis';
 
-import { ScheduleListResponse, ScheduleRegisterRequest } from './types';
-import { ConsultationListResponse } from './types';
+import {
+  ConsultationListResponse,
+  ScheduleListResponse,
+  ScheduleRegisterRequest,
+} from './types';
 
 export const getSchedule = async (): Promise<ScheduleListResponse> => {
   const response = await apiInstance.get<ScheduleListResponse>(

--- a/src/apis/mentor/index.tsx
+++ b/src/apis/mentor/index.tsx
@@ -1,6 +1,7 @@
 import apiInstance from '@/apis';
 
 import { ScheduleListResponse, ScheduleRegisterRequest } from './types';
+import { ConsultationListResponse } from './types';
 
 export const getSchedule = async (): Promise<ScheduleListResponse> => {
   const response = await apiInstance.get<ScheduleListResponse>(
@@ -19,4 +20,30 @@ export const deleteSchedule = async (
   data: ScheduleRegisterRequest
 ): Promise<void> => {
   await apiInstance.delete('/api/v1/consultation/schedule', { data });
+};
+
+export const getConsultations = async (
+  page: number,
+  size: number,
+  consultationStatus: string
+): Promise<ConsultationListResponse> => {
+  const response = await apiInstance.get<ConsultationListResponse>(
+    '/api/v1/member/consultation',
+    {
+      params: {
+        page,
+        size,
+        consultation_status: consultationStatus,
+      },
+    }
+  );
+  return response.data;
+};
+
+export const confirmConsultation = async (id: number): Promise<void> => {
+  await apiInstance.put(`/api/v1/consultation/${id}`);
+};
+
+export const rejectConsultation = async (id: number): Promise<void> => {
+  await apiInstance.delete(`/api/v1/consultation/${id}`);
 };

--- a/src/apis/mentor/index.tsx
+++ b/src/apis/mentor/index.tsx
@@ -1,0 +1,22 @@
+import apiInstance from '@/apis';
+
+import { ScheduleListResponse, ScheduleRegisterRequest } from './types';
+
+export const getSchedule = async (): Promise<ScheduleListResponse> => {
+  const response = await apiInstance.get<ScheduleListResponse>(
+    '/api/v1/consultation/schedule'
+  );
+  return response.data;
+};
+
+export const registerSchedule = async (
+  data: ScheduleRegisterRequest
+): Promise<void> => {
+  await apiInstance.post('/api/v1/consultation/schedule', data);
+};
+
+export const deleteSchedule = async (
+  data: ScheduleRegisterRequest
+): Promise<void> => {
+  await apiInstance.delete('/api/v1/consultation/schedule', { data });
+};

--- a/src/apis/mentor/types.ts
+++ b/src/apis/mentor/types.ts
@@ -1,0 +1,11 @@
+export interface ScheduleListResponse {
+  list: {
+    [date: string]: number[];
+  };
+}
+
+export interface ScheduleRegisterRequest {
+  list: {
+    [date: string]: number[];
+  };
+}

--- a/src/apis/mentor/types.ts
+++ b/src/apis/mentor/types.ts
@@ -9,3 +9,19 @@ export interface ScheduleRegisterRequest {
     [date: string]: number[];
   };
 }
+
+export interface ConsultationContent {
+  id: number;
+  mentor_nick_name: string;
+  mentee_nick_name: string;
+  consultation_date_time: string;
+  consultation_status: 'RECEIVED' | 'FINISHED' | string;
+  title: string;
+  content: string;
+}
+
+export interface ConsultationListResponse {
+  total_page: number;
+  current_page: number;
+  content: ConsultationContent[];
+}

--- a/src/components/MentorConsultingManagement/ConfirmConsultingRequest/LoadingButton.tsx
+++ b/src/components/MentorConsultingManagement/ConfirmConsultingRequest/LoadingButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { Button, ButtonProps, Flex, Spinner } from '@chakra-ui/react';
+
+interface LoadingButtonProps extends ButtonProps {
+  isLoading?: boolean;
+}
+
+export const LoadingButton: React.FC<LoadingButtonProps> = ({
+  isLoading = false,
+  children,
+  ...props
+}) => {
+  return (
+    <Button {...props} isDisabled={isLoading}>
+      {isLoading ? (
+        <Flex alignItems="center">
+          <Spinner size="sm" mr="2" />
+          로딩 중...
+        </Flex>
+      ) : (
+        children
+      )}
+    </Button>
+  );
+};

--- a/src/components/MentorConsultingManagement/ConfirmConsultingRequest/index.tsx
+++ b/src/components/MentorConsultingManagement/ConfirmConsultingRequest/index.tsx
@@ -1,4 +1,10 @@
 import {
+  confirmConsultation,
+  getConsultations,
+  rejectConsultation,
+} from '@/apis/mentor';
+import { ConsultationListResponse } from '@/apis/mentor/types';
+import {
   ConsultingInfoBox,
   ConsultingInfoItem,
 } from '@/components/ConsultingManagement/ConsultingInfoBox';
@@ -7,61 +13,76 @@ import { BoomerangButton } from '@/components/commons/BoomerangButton';
 import { BoomerangColors } from '@/utils/colors';
 import { Box, Button, Flex, Image, Text, VStack } from '@chakra-ui/react';
 import roundCheck from '@images/roundCheck.svg';
-
-const ConsultingInfo: ConsultingInfoItem[][] = [
-  [
-    {
-      title: '상담 일정',
-      content: '24/10/22 오후 3시~ 오후 4시',
-    },
-    {
-      title: '신청자명',
-      content: '김땡땡',
-    },
-    {
-      title: '신청 내용',
-      content:
-        '주택 전세사기를 당했어요... 주택 전세사기를 당했어요...주택 전세사기를 당했어요...주택 전세사기를 당했어요...',
-    },
-  ],
-  [
-    {
-      title: '상담 일정',
-      content: '24/10/22 오후 3시~ 오후 4시',
-    },
-    {
-      title: '신청자명',
-      content: '김땡땡',
-    },
-    {
-      title: '신청 내용',
-      content:
-        '주택 전세사기를 당했어요... 주택 전세사기를 당했어요...주택 전세사기를 당했어요...주택 전세사기를 당했어요...',
-    },
-  ],
-];
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 export const ConfirmConsultingRequest = () => {
+  const { data, isLoading, isError } = useQuery<ConsultationListResponse>({
+    queryKey: [
+      'consultations',
+      { page: 0, size: 10, consultation_status: 'RECEIVED' },
+    ],
+    queryFn: () => getConsultations(0, 10, 'RECEIVED'),
+  });
+
+  if (isLoading) {
+    return (
+      <Box flex="1" bg="white">
+        <ConsultingManagementHeader category="신청 내역 확인하기" />
+        <VStack mt="59px" pb="69px" justifyContent="center">
+          <Text>로딩 중...</Text>
+        </VStack>
+      </Box>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <Box flex="1" bg="white">
+        <ConsultingManagementHeader category="신청 내역 확인하기" />
+        <VStack mt="59px" pb="69px" justifyContent="center">
+          <Text>데이터를 불러오는데 실패했습니다.</Text>
+        </VStack>
+      </Box>
+    );
+  }
+
   return (
     <Box flex="1" bg="white">
       <ConsultingManagementHeader category="신청 내역 확인하기" />
       <VStack mt="59px" pb="69px" justifyContent="center">
         <Flex gap="15px" mb="45px" w="883px">
-          <Image src={roundCheck} />
+          <Image src={roundCheck} alt="Round Check" />
           <Text fontWeight="bold" fontSize="30px" color="#373737">
-            현재 2건의 상담 신청이 들어왔어요!
+            현재 {data!.content.length}건의 상담 신청이 들어왔어요!
           </Text>
         </Flex>
         <Box>
           <Text fontSize="18px" fontWeight="bold" color="#979797" mb="17px">
             요청된 상담 내역
           </Text>
-          {ConsultingInfo.map((record) => (
-            <ConsultingRequestRecord
-              key={record[1].content}
-              infoList={record}
-            />
-          ))}
+          {data.content.map((consultation) => {
+            const infoList: ConsultingInfoItem[] = [
+              {
+                title: '상담 일정',
+                content: consultation.consultation_date_time,
+              },
+              {
+                title: '신청자명',
+                content: consultation.mentee_nick_name,
+              },
+              {
+                title: '신청 내용',
+                content: consultation.content,
+              },
+            ];
+            return (
+              <ConsultingRequestRecord
+                key={consultation.id}
+                infoList={infoList}
+                consultationId={consultation.id}
+              />
+            );
+          })}
         </Box>
       </VStack>
     </Box>
@@ -70,15 +91,57 @@ export const ConfirmConsultingRequest = () => {
 
 const ConsultingRequestRecord = ({
   infoList,
+  consultationId,
 }: {
   infoList: ConsultingInfoItem[];
+  consultationId: number;
 }) => {
+  const queryClient = useQueryClient();
+
+  const confirmMutation = useMutation({
+    mutationFn: () => confirmConsultation(consultationId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [
+          'consultations',
+          { page: 0, size: 10, consultation_status: 'RECEIVED' },
+        ],
+      });
+    },
+    onError: (_error) => {
+      //TODO: 에러처리
+    },
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: () => rejectConsultation(consultationId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [
+          'consultations',
+          { page: 0, size: 10, consultation_status: 'RECEIVED' },
+        ],
+      });
+    },
+    onError: (_error) => {
+      //TODO: 에러처리
+    },
+  });
+
   return (
     <VStack spacing={0} alignItems="flex-end" mb="68px">
       <ConsultingInfoBox infoList={infoList} />
       <Flex gap="34px" mt="15px">
-        <BoomerangButton w="179px" h="51px" fontSize="22px" onClick={() => ''}>
-          상담 확정하기
+        <BoomerangButton
+          w="179px"
+          h="51px"
+          fontSize="22px"
+          onClick={() => {
+            confirmMutation.mutate();
+          }}
+          // TODO : isLoading prop 에러 해결해야함
+        >
+          {confirmMutation.isLoading ? '로딩 중...' : '상담 확정하기'}
         </BoomerangButton>
         <Button
           width="133px"
@@ -89,7 +152,10 @@ const ConsultingRequestRecord = ({
           color={BoomerangColors.white}
           fontSize="22px"
           fontWeight="bold"
-          onClick={() => ''}
+          onClick={() => {
+            rejectMutation.mutate();
+          }}
+          isLoading={rejectMutation.isLoading}
           _hover={{}}
         >
           거절하기

--- a/src/components/MentorConsultingManagement/ConfirmConsultingRequest/index.tsx
+++ b/src/components/MentorConsultingManagement/ConfirmConsultingRequest/index.tsx
@@ -110,6 +110,7 @@ const ConsultingRequestRecord = ({
     },
     onError: (_error) => {
       //TODO: 에러처리
+      console.log(_error);
     },
   });
 
@@ -125,6 +126,7 @@ const ConsultingRequestRecord = ({
     },
     onError: (_error) => {
       //TODO: 에러처리
+      console.log(_error);
     },
   });
 

--- a/src/components/MentorConsultingManagement/ConfirmConsultingRequest/index.tsx
+++ b/src/components/MentorConsultingManagement/ConfirmConsultingRequest/index.tsx
@@ -9,19 +9,20 @@ import {
   ConsultingInfoItem,
 } from '@/components/ConsultingManagement/ConsultingInfoBox';
 import { ConsultingManagementHeader } from '@/components/ConsultingManagement/ConsultingManagementHeader';
-import { BoomerangButton } from '@/components/commons/BoomerangButton';
 import { BoomerangColors } from '@/utils/colors';
-import { Box, Button, Flex, Image, Text, VStack } from '@chakra-ui/react';
+import { Box, Flex, Image, Text, VStack, useToast } from '@chakra-ui/react';
 import roundCheck from '@images/roundCheck.svg';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { LoadingButton } from './LoadingButton';
 
 export const ConfirmConsultingRequest = () => {
   const { data, isLoading, isError } = useQuery<ConsultationListResponse>({
     queryKey: [
       'consultations',
-      { page: 0, size: 10, consultation_status: 'RECEIVED' },
+      { page: 0, size: 20, consultation_status: 'RECEIVED' },
     ],
-    queryFn: () => getConsultations(0, 10, 'RECEIVED'),
+    queryFn: () => getConsultations(0, 20, 'RECEIVED'),
   });
 
   if (isLoading) {
@@ -53,7 +54,7 @@ export const ConfirmConsultingRequest = () => {
         <Flex gap="15px" mb="45px" w="883px">
           <Image src={roundCheck} alt="Round Check" />
           <Text fontWeight="bold" fontSize="30px" color="#373737">
-            현재 {data!.content.length}건의 상담 신청이 들어왔어요!
+            현재 {data.content.length}건의 상담 신청이 들어왔어요!
           </Text>
         </Flex>
         <Box>
@@ -97,6 +98,7 @@ const ConsultingRequestRecord = ({
   consultationId: number;
 }) => {
   const queryClient = useQueryClient();
+  const toast = useToast();
 
   const confirmMutation = useMutation({
     mutationFn: () => confirmConsultation(consultationId),
@@ -104,13 +106,23 @@ const ConsultingRequestRecord = ({
       queryClient.invalidateQueries({
         queryKey: [
           'consultations',
-          { page: 0, size: 10, consultation_status: 'RECEIVED' },
+          { page: 0, size: 20, consultation_status: 'RECEIVED' },
         ],
       });
+      toast({
+        title: '상담 확정 완료',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
     },
-    onError: (_error) => {
-      //TODO: 에러처리
-      console.log(_error);
+    onError: () => {
+      toast({
+        title: '상담 확정 실패',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
     },
   });
 
@@ -120,13 +132,23 @@ const ConsultingRequestRecord = ({
       queryClient.invalidateQueries({
         queryKey: [
           'consultations',
-          { page: 0, size: 10, consultation_status: 'RECEIVED' },
+          { page: 0, size: 20, consultation_status: 'RECEIVED' },
         ],
       });
+      toast({
+        title: '상담 거절 완료',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
     },
-    onError: (_error) => {
-      //TODO: 에러처리
-      console.log(_error);
+    onError: () => {
+      toast({
+        title: '상담 거절 실패',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
     },
   });
 
@@ -134,34 +156,35 @@ const ConsultingRequestRecord = ({
     <VStack spacing={0} alignItems="flex-end" mb="68px">
       <ConsultingInfoBox infoList={infoList} />
       <Flex gap="34px" mt="15px">
-        <BoomerangButton
+        <LoadingButton
           w="179px"
           h="51px"
           fontSize="22px"
           onClick={() => {
             confirmMutation.mutate();
           }}
-          // TODO : isLoading prop 에러 해결해야함
-        >
-          {confirmMutation.isLoading ? '로딩 중...' : '상담 확정하기'}
-        </BoomerangButton>
-        <Button
-          width="133px"
-          height="51px"
+          isLoading={confirmMutation.status === 'pending'}
+          bg="blue.500"
+          color="white"
           borderRadius={5}
-          bg="#FC5C7D"
-          shadow="1px 1px 4px rgba(0, 0, 0, 0.25)"
-          color={BoomerangColors.white}
+        >
+          상담 확정하기
+        </LoadingButton>
+        <LoadingButton
+          w="133px"
+          h="51px"
           fontSize="22px"
-          fontWeight="bold"
           onClick={() => {
             rejectMutation.mutate();
           }}
-          isLoading={rejectMutation.isLoading}
-          _hover={{}}
+          isLoading={rejectMutation.status === 'pending'}
+          bg="#FC5C7D"
+          shadow="1px 1px 4px rgba(0, 0, 0, 0.25)"
+          color={BoomerangColors.white}
+          borderRadius={5}
         >
           거절하기
-        </Button>
+        </LoadingButton>
       </Flex>
     </VStack>
   );

--- a/src/components/MentorConsultingManagement/MentorConsultingHistory/MentorConsultingInfoBox.tsx
+++ b/src/components/MentorConsultingManagement/MentorConsultingHistory/MentorConsultingInfoBox.tsx
@@ -9,14 +9,19 @@ interface MentorConsultingInfoItem {
   content: string | number;
 }
 
-export const MentorConsultingInfoBox = ({
-  infoList,
-}: {
+interface MentorConsultingInfoBoxProps {
   infoList: MentorConsultingInfoItem[];
-}) => {
+  chatId: number;
+}
+
+export const MentorConsultingInfoBox: React.FC<
+  MentorConsultingInfoBoxProps
+> = ({ infoList, chatId }) => {
   const navigate = useNavigate();
-  //TODO: 수정
-  const chatId = 1;
+
+  const goConsultingChat = () => {
+    navigate(`/mentor/scheduled/chat/${chatId}`);
+  };
 
   return (
     <Flex
@@ -28,8 +33,8 @@ export const MentorConsultingInfoBox = ({
       overflowY="auto"
       position="relative"
     >
-      {infoList.map((item) => (
-        <MentorConsultingInfoItem
+      {infoList.map((item: MentorConsultingInfoItem) => (
+        <MentorConsultingInfoItemComponent
           key={item.title}
           title={item.title}
           content={item.content}
@@ -40,7 +45,7 @@ export const MentorConsultingInfoBox = ({
           w="179px"
           h="40px"
           fontSize="15px"
-          onClick={() => navigate(`/mentor/scheduled/chat/${chatId}`)}
+          onClick={goConsultingChat}
         >
           과거 상담 채팅 조회하기
         </BoomerangButton>
@@ -49,13 +54,10 @@ export const MentorConsultingInfoBox = ({
   );
 };
 
-const MentorConsultingInfoItem = ({
-  title,
-  content,
-}: {
+const MentorConsultingInfoItemComponent: React.FC<{
   title: string;
   content: string | number;
-}) => (
+}> = ({ title, content }) => (
   <Flex fontSize="20px" fontWeight="bold" color="#176CFF" gap="135px">
     <Text w="135px">{title}</Text>
     {title === '신청자 상담 평가' && typeof content === 'number' ? (

--- a/src/components/MentorConsultingManagement/MentorDateRegistration/MentorDaySection/index.css
+++ b/src/components/MentorConsultingManagement/MentorDateRegistration/MentorDaySection/index.css
@@ -1,0 +1,102 @@
+.react-calendar {
+  width: 600px;
+  max-width: 100%;
+  height: 100%;
+  background: white;
+  border-top: 2px solid #176cff;
+  border-bottom: 2px solid #176cff;
+  line-height: 1.125em;
+}
+
+.react-calendar__navigation {
+  display: flex;
+  height: 44px;
+  margin-bottom: 1em;
+}
+
+.react-calendar__navigation button {
+  min-width: 44px;
+  background: none;
+  border: none;
+}
+
+.react-calendar__navigation__label {
+  font-size: 1.25em;
+  font-weight: bold;
+  color: black;
+}
+
+.react-calendar__navigation__prev-button,
+.react-calendar__navigation__next-button {
+  color: black;
+  opacity: 1;
+}
+
+.react-calendar__month-view__weekdays {
+  text-align: center;
+  font-weight: bold;
+  font-size: 0.875em;
+}
+
+.react-calendar__month-view__weekdays__weekday {
+  padding: 0.5em;
+  color: #757575;
+}
+
+.react-calendar__month-view__weekdays__weekday abbr[title] {
+  text-decoration: none;
+}
+
+.react-calendar__month-view__days__day--weekend {
+  color: #d10000;
+}
+
+.react-calendar__tile {
+  max-width: 100%;
+  padding: 19px 15px;
+  background: none;
+  text-align: center;
+  font: inherit;
+  font-size: 1em;
+  border-radius: 8px;
+}
+
+.react-calendar__tile:enabled:hover,
+.react-calendar__tile:enabled:focus {
+  background-color: #f0f0f0;
+}
+
+.react-calendar__tile--now {
+  color: black;
+  border: 2px solid #4488ff;
+  border-radius: 8px;
+}
+
+.react-calendar__tile--now:enabled:hover,
+.react-calendar__tile--now:enabled:focus {
+  background: #176cff;
+  color: white;
+}
+
+.react-calendar__tile--active {
+  background: #4488ff;
+  color: white;
+  border-radius: 8px;
+}
+
+.react-calendar__tile--active:enabled:hover,
+.react-calendar__tile--active:enabled:focus {
+  background: #176cff;
+}
+
+.react-calendar__month-view__days__day--weekend:nth-child(7) {
+  color: #c4c4c4;
+}
+
+.react-calendar__month-view__weekdays__weekday:first-child {
+  color: #c4c4c4;
+}
+
+.react-calendar__month-view__days__day--neighboringMonth:disabled {
+  color: #e0e0e0;
+}

--- a/src/components/MentorConsultingManagement/MentorDateRegistration/MentorDaySection/index.tsx
+++ b/src/components/MentorConsultingManagement/MentorDateRegistration/MentorDaySection/index.tsx
@@ -1,0 +1,152 @@
+import { useEffect } from 'react';
+import Calendar from 'react-calendar';
+
+import { ServerError } from '@/apis/errors';
+import { getSchedule } from '@/apis/mentor';
+import { ScheduleListResponse } from '@/apis/mentor/types';
+import { ConsultingItemTitle } from '@/components/ConsultingManagement/ConsultingItemTitle';
+import { BoomerangColors } from '@/utils/colors';
+import { Box, Button, Flex, VStack } from '@chakra-ui/react';
+import pointer from '@images/pointer.svg';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+import './index.css';
+
+const times: string[] = Array.from({ length: 15 }, (_, i) => {
+  const hour = (9 + i).toString().padStart(2, '0');
+  return `${hour}:00`;
+});
+
+type ReservedTimes = {
+  [date: string]: number[];
+};
+
+type ValuePiece = Date | null;
+type Value = ValuePiece | [ValuePiece, ValuePiece];
+
+export const DaySection: React.FC<{
+  selectedDate: Date | null;
+  setSelectedDate: (value: Date | null) => void;
+  selectedTimes: number[];
+  setSelectedTimes: React.Dispatch<React.SetStateAction<number[]>>;
+}> = ({ selectedDate, setSelectedDate, selectedTimes, setSelectedTimes }) => {
+  const { data: scheduleData, error } = useQuery<ScheduleListResponse>({
+    queryKey: ['schedules'],
+    queryFn: getSchedule,
+  });
+
+  useEffect(() => {
+    if (error) {
+      let message = '일정 조회에 실패했습니다.';
+      if (axios.isAxiosError(error)) {
+        const serverError = error.response?.data as ServerError;
+        if (serverError && serverError.message) {
+          message = serverError.message;
+        }
+      }
+      alert(message);
+    }
+  }, [error]);
+
+  const reservedTimes: ReservedTimes = scheduleData?.list || {};
+
+  const handleDateChange = (value: Value) => {
+    if (value instanceof Date) {
+      setSelectedDate(value);
+      setSelectedTimes([]);
+    }
+  };
+
+  const getReservedTimes = (): number[] => {
+    if (!selectedDate) return [];
+    const dateString = selectedDate.toISOString().split('T')[0];
+    return reservedTimes[dateString] || [];
+  };
+
+  const toggleTimeSelection = (timeIndex: number) => {
+    setSelectedTimes((prevSelectedTimes) => {
+      if (prevSelectedTimes.includes(timeIndex)) {
+        return prevSelectedTimes.filter((t) => t !== timeIndex);
+      } else {
+        return [...prevSelectedTimes, timeIndex];
+      }
+    });
+  };
+
+  const isTimeReserved = (timeIndex: number): boolean => {
+    return getReservedTimes().includes(timeIndex);
+  };
+
+  return (
+    <Box w="951px">
+      <ConsultingItemTitle
+        title="원하시는 상담 날짜를 선택해주세요!"
+        icon={pointer}
+      />
+      <VStack justifyContent="center">
+        <Flex w="870px" h="394px" borderRadius="17px">
+          <Calendar
+            onChange={handleDateChange}
+            value={selectedDate ?? new Date()}
+            locale="ko"
+            calendarType="gregory"
+            view="month"
+            prev2Label={null}
+            next2Label={null}
+            showNeighboringMonth={false}
+          />
+          <Box
+            borderTop={`2px solid ${BoomerangColors.deepBlue}`}
+            borderBottom={`2px solid ${BoomerangColors.deepBlue}`}
+          >
+            <Flex
+              maxW={300}
+              wrap="wrap"
+              justifyContent="center"
+              alignItems="center"
+              gap={2}
+              h="100%"
+              p="5px 0"
+            >
+              {times.map((time, index) => {
+                const isReserved = isTimeReserved(index);
+                const isSelected = selectedTimes.includes(index);
+
+                let variant = 'outline';
+                let colorScheme = 'blue';
+
+                if (isReserved && isSelected) {
+                  variant = 'solid';
+                  colorScheme = 'red';
+                } else if (isReserved) {
+                  variant = 'outline';
+                  colorScheme = 'red';
+                } else if (isSelected) {
+                  variant = 'solid';
+                  colorScheme = 'blue';
+                }
+
+                return (
+                  <Button
+                    key={time}
+                    onClick={() => toggleTimeSelection(index)}
+                    border="none"
+                    variant={variant}
+                    colorScheme={colorScheme}
+                    width="70px"
+                    height="40px"
+                    fontSize="1rem"
+                    fontWeight={500}
+                  >
+                    {time}
+                  </Button>
+                );
+              })}
+            </Flex>
+          </Box>
+        </Flex>
+      </VStack>
+    </Box>
+  );
+};

--- a/src/components/MentorConsultingManagement/MentorDateRegistration/index.tsx
+++ b/src/components/MentorConsultingManagement/MentorDateRegistration/index.tsx
@@ -82,7 +82,7 @@ export const MentorDateRegistration = () => {
           selectedTimes={selectedTimes}
           setSelectedTimes={setSelectedTimes}
         />
-        <Flex justifyContent="flex-end" w="876px" mt="15px">
+        <Flex justifyContent="flex-end" w="876px" mt="15px" gap="15px">
           <BoomerangButton
             w="154px"
             h="47px"

--- a/src/components/MentorConsultingManagement/MentorDateRegistration/index.tsx
+++ b/src/components/MentorConsultingManagement/MentorDateRegistration/index.tsx
@@ -1,27 +1,86 @@
 import { useState } from 'react';
 
+import { ServerError } from '@/apis/errors';
+import { deleteSchedule, registerSchedule } from '@/apis/mentor';
+import { ScheduleRegisterRequest } from '@/apis/mentor/types';
 import { ConsultingManagementHeader } from '@/components/ConsultingManagement/ConsultingManagementHeader';
-import { SelectConsultingDaySection } from '@/components/ConsultingManagement/ConsultingScheduling/SelectConsultingDaySection';
 import { BoomerangButton } from '@/components/commons/BoomerangButton';
 import { Box, Flex, VStack } from '@chakra-ui/react';
+import { useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+
+import { DaySection } from './MentorDaySection';
 
 export const MentorDateRegistration = () => {
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-  const [selectedTime, setSelectedTime] = useState<string>('');
+  const [selectedTimes, setSelectedTimes] = useState<number[]>([]);
+  const queryClient = useQueryClient();
 
-  const registrationDate = () => {
-    console.log(selectedDate, selectedTime);
+  const registrationDate = async () => {
+    if (selectedDate && selectedTimes.length > 0) {
+      const dateString = selectedDate.toISOString().split('T')[0];
+      const data: ScheduleRegisterRequest = {
+        list: {
+          [dateString]: selectedTimes,
+        },
+      };
+      try {
+        await registerSchedule(data);
+        alert('일정이 성공적으로 등록되었습니다.');
+        setSelectedTimes([]);
+        await queryClient.invalidateQueries({ queryKey: ['schedules'] });
+      } catch (error: unknown) {
+        let message = '일정 등록에 실패했습니다.';
+        if (axios.isAxiosError(error)) {
+          const serverError = error.response?.data as ServerError;
+          if (serverError && serverError.message) {
+            message = serverError.message;
+          }
+        }
+        alert(message);
+      }
+    } else {
+      alert('날짜와 시간을 선택해주세요.');
+    }
+  };
+
+  const cancelSchedule = async () => {
+    if (selectedDate && selectedTimes.length > 0) {
+      const dateString = selectedDate.toISOString().split('T')[0];
+      const data: ScheduleRegisterRequest = {
+        list: {
+          [dateString]: selectedTimes,
+        },
+      };
+      try {
+        await deleteSchedule(data);
+        alert('일정이 성공적으로 삭제되었습니다.');
+        setSelectedTimes([]);
+        await queryClient.invalidateQueries({ queryKey: ['schedules'] });
+      } catch (error: unknown) {
+        let message = '일정 삭제에 실패했습니다.';
+        if (axios.isAxiosError(error)) {
+          const serverError = error.response?.data as ServerError;
+          if (serverError && serverError.message) {
+            message = serverError.message;
+          }
+        }
+        alert(message);
+      }
+    } else {
+      alert('삭제할 날짜와 시간을 선택해주세요.');
+    }
   };
 
   return (
     <Box flex="1" bg="white">
       <ConsultingManagementHeader category="상담 일자 등록하기" />
       <VStack mt="56px">
-        <SelectConsultingDaySection
+        <DaySection
           selectedDate={selectedDate}
           setSelectedDate={setSelectedDate}
-          selectedTime={selectedTime}
-          setSelectedTime={setSelectedTime}
+          selectedTimes={selectedTimes}
+          setSelectedTimes={setSelectedTimes}
         />
         <Flex justifyContent="flex-end" w="876px" mt="15px">
           <BoomerangButton
@@ -30,7 +89,15 @@ export const MentorDateRegistration = () => {
             fontSize="24px"
             onClick={registrationDate}
           >
-            적용하기
+            등록하기
+          </BoomerangButton>
+          <BoomerangButton
+            w="154px"
+            h="47px"
+            fontSize="24px"
+            onClick={cancelSchedule}
+          >
+            삭제하기
           </BoomerangButton>
         </Flex>
       </VStack>

--- a/src/components/MentorConsultingManagement/MentorScheduledConsulting/index.tsx
+++ b/src/components/MentorConsultingManagement/MentorScheduledConsulting/index.tsx
@@ -1,66 +1,80 @@
 import { useNavigate } from 'react-router-dom';
 
+import { getConsultations } from '@/apis/mentor';
+import {
+  ConsultationContent,
+  ConsultationListResponse,
+} from '@/apis/mentor/types';
 import {
   ConsultingInfoBox,
   ConsultingInfoItem,
 } from '@/components/ConsultingManagement/ConsultingInfoBox';
 import { ConsultingManagementHeader } from '@/components/ConsultingManagement/ConsultingManagementHeader';
 import { BoomerangColors } from '@/utils/colors';
-import { Box, Button, Flex, Image, Text, VStack } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Center,
+  Flex,
+  Image,
+  Spinner,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
 import paper from '@images/paper.svg';
-
-const ConsultingInfo: ConsultingInfoItem[][] = [
-  [
-    {
-      title: '상담 일정',
-      content: '24/10/22 오후 3시~ 오후 4시',
-    },
-    {
-      title: '신청자명',
-      content: '김땡땡',
-    },
-    {
-      title: '신청 내용',
-      content:
-        '주택 전세사기를 당했어요... 주택 전세사기를 당했어요...주택 전세사기를 당했어요...주택 전세사기를 당했어요...',
-    },
-  ],
-  [
-    {
-      title: '상담 일정',
-      content: '24/10/22 오후 3시~ 오후 4시',
-    },
-    {
-      title: '신청자명',
-      content: '김땡땡',
-    },
-    {
-      title: '신청 내용',
-      content:
-        '주택 전세사기를 당했어요... 주택 전세사기를 당했어요...주택 전세사기를 당했어요...주택 전세사기를 당했어요...',
-    },
-  ],
-];
+import { useQuery } from '@tanstack/react-query';
 
 export const MentorScheduledConsulting = () => {
+  const { data, isLoading, isError } = useQuery<
+    ConsultationListResponse,
+    Error
+  >({
+    queryKey: [
+      'consultations',
+      { page: 0, size: 30, consultation_status: 'PENDING' },
+    ],
+    queryFn: () => getConsultations(0, 30, 'PENDING'),
+  });
+
+  if (isLoading) {
+    return (
+      <Center flex="1" bg="white">
+        <Spinner size="xl" />
+      </Center>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <Center flex="1" bg="white">
+        <Text color="red.500">상담 내역을 불러오는 데 실패했습니다.</Text>
+      </Center>
+    );
+  }
+
   return (
     <Box flex="1" bg="white">
       <ConsultingManagementHeader category="상담 예정 내용 확인하기" />
       <VStack mt="59px" pb="69px" justifyContent="center">
         <Flex gap="15px" mb="45px" w="883px">
-          <Image src={paper} />
+          <Image src={paper} alt="Paper Icon" />
           <Text fontWeight="bold" fontSize="30px" color="#373737">
-            현재 2건의 상담이 예정되어있어요!
+            현재 {data!.content.length}건의 상담이 예정되어있어요!
           </Text>
         </Flex>
         <Box>
           <Text fontSize="18px" fontWeight="bold" color="#979797" mb="17px">
             요청된 상담 내역
           </Text>
-          {ConsultingInfo.map((record) => (
+          {data!.content.map((item: ConsultationContent) => (
             <ScheduledConsultingRecord
-              key={record[1].content}
-              infoList={record}
+              key={item.id}
+              infoList={[
+                { title: '상담 일정', content: item.consultation_date_time },
+                { title: '신청자명', content: item.mentee_nick_name },
+                { title: '신청 내용', content: item.content },
+              ]}
+              consultationId={item.id}
             />
           ))}
         </Box>
@@ -71,21 +85,21 @@ export const MentorScheduledConsulting = () => {
 
 const ScheduledConsultingRecord = ({
   infoList,
+  consultationId,
 }: {
   infoList: ConsultingInfoItem[];
+  consultationId: number;
 }) => {
   return (
     <VStack spacing={0} alignItems="flex-end">
       <ConsultingInfoBox infoList={infoList} />
-      <ConsultingStartBtn />
+      <ConsultingStartBtn chatId={consultationId} />
     </VStack>
   );
 };
 
-const ConsultingStartBtn = () => {
+const ConsultingStartBtn = ({ chatId }: { chatId: number }) => {
   const navigate = useNavigate();
-  //TODO: 추후 수정
-  const chatId = 1;
 
   const goConsultingChat = () => {
     navigate(`/mentor/scheduled/chat/${chatId}`);


### PR DESCRIPTION
## 📖️ 제목 멘토 페이지 api 연동

##### 반영 브랜치 : `seongik -> Week10`

### 🛠️ 작업 사항
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 세팅 (의존성, 환경 변수, 빌드 관련 코드)

### ️️ 📝 설명
    멘토페이지의 상담 일자 등록 , 신청 내역 확인 , 상담 예정내용 확인 , 과거 상담내역 조회의 API 연동하였습니다.

